### PR TITLE
Add : 공통 응답용 ApiResponse 추가

### DIFF
--- a/src/main/java/com/sprarta/sproutmarket/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/sprarta/sproutmarket/config/GlobalExceptionHandler.java
@@ -1,0 +1,33 @@
+package com.sprarta.sproutmarket.config;
+
+import com.sprarta.sproutmarket.domain.common.ApiResponse;
+import com.sprarta.sproutmarket.domain.common.dto.response.ReasonDto;
+import com.sprarta.sproutmarket.domain.common.exception.ApiException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    //공통 예외 처리
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ApiResponse<String>> handleApiException(ApiException ex) {
+        ReasonDto status = ex.getErrorCode().getReasonHttpStatus();
+        return getErrorResponse(status.getHttpStatus(), status.getMessage());
+    }
+
+    //파일 첨부 용량 초과 예외
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ApiResponse<String>> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException ex) {
+        HttpStatus status = HttpStatus.REQUEST_ENTITY_TOO_LARGE;
+        return getErrorResponse(status, "파일 크기는 5MB를 초과할 수 없습니다.");
+    }
+
+    public ResponseEntity<ApiResponse<String>> getErrorResponse(HttpStatus status, String message) {
+
+        return new ResponseEntity<>(ApiResponse.createError(message, status.value()), status);
+    }
+}

--- a/src/main/java/com/sprarta/sproutmarket/config/SecurityConfig.java
+++ b/src/main/java/com/sprarta/sproutmarket/config/SecurityConfig.java
@@ -39,7 +39,10 @@ public class SecurityConfig {
                 .httpBasic(AbstractHttpConfigurer::disable)
                 .logout(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/**", "/notifications/**").permitAll()
+                        .requestMatchers("/auth/**",
+                                "/test/**",
+                                "/error/**",
+                                "/notifications/**").permitAll()
                         .requestMatchers("/admin/**").hasAuthority(UserRole.ADMIN.name())
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/sprarta/sproutmarket/domain/apiResponseExample/TestController.java
+++ b/src/main/java/com/sprarta/sproutmarket/domain/apiResponseExample/TestController.java
@@ -1,0 +1,29 @@
+package com.sprarta.sproutmarket.domain.apiResponseExample;
+
+import com.sprarta.sproutmarket.domain.common.ApiResponse;
+import com.sprarta.sproutmarket.domain.common.enums.ErrorStatus;
+import com.sprarta.sproutmarket.domain.common.exception.ApiException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class TestController {
+
+    //정상적으로 작동했을 때의 응답 예시
+    @GetMapping("/test/hello")
+    public ResponseEntity<ApiResponse<String>> hello() {
+        return ResponseEntity.ok(ApiResponse.onSuccess("반갑습니다."));
+    }
+
+    //사용했는데 예외가 터지는 예시
+    @GetMapping("/test/unhello")
+    public ResponseEntity<ApiResponse<String>> unhello() {
+        return ResponseEntity.ok(ApiResponse.onSuccess(throwExample()));
+    }
+
+    //예시라서 서비스 클래스 따로 안 만들고 여기서 만들었습니다.
+    public String throwExample() {
+        throw new ApiException(ErrorStatus.TEST_ERROR);
+    }
+}

--- a/src/main/java/com/sprarta/sproutmarket/domain/common/ApiResponse.java
+++ b/src/main/java/com/sprarta/sproutmarket/domain/common/ApiResponse.java
@@ -1,0 +1,34 @@
+package com.sprarta.sproutmarket.domain.common;
+
+import com.sprarta.sproutmarket.domain.common.enums.ErrorStatus;
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+
+    private final String message;
+    private final Integer statusCode;
+    private final T data;
+
+    private ApiResponse(String message, Integer statusCode, T data) {
+        this.message = message;
+        this.statusCode = statusCode;
+        this.data = data;
+    }
+
+    public static <T> ApiResponse<T> createSuccess(String message, Integer statusCode, T data) {
+        return new ApiResponse<>(message,statusCode,data);
+    }
+
+    public static <T> ApiResponse<T> createError(String message,Integer statusCode) {
+        return new ApiResponse<>(message,statusCode,null);
+    }
+
+    public static <T> ApiResponse<T> onSuccess(T result) {
+        return new ApiResponse<>("Ok", 200, result);
+    }
+
+    public static ApiResponse<String> onFailure(ErrorStatus errorStatus) {
+        return new ApiResponse<>(errorStatus.getMessage(), errorStatus.getStatusCode(), null);
+    }
+}

--- a/src/main/java/com/sprarta/sproutmarket/domain/common/BaseCode.java
+++ b/src/main/java/com/sprarta/sproutmarket/domain/common/BaseCode.java
@@ -1,0 +1,7 @@
+package com.sprarta.sproutmarket.domain.common;
+
+import com.sprarta.sproutmarket.domain.common.dto.response.ReasonDto;
+
+public interface BaseCode {
+    ReasonDto getReasonHttpStatus();
+}

--- a/src/main/java/com/sprarta/sproutmarket/domain/common/dto/response/ReasonDto.java
+++ b/src/main/java/com/sprarta/sproutmarket/domain/common/dto/response/ReasonDto.java
@@ -1,0 +1,13 @@
+package com.sprarta.sproutmarket.domain.common.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Builder
+@Getter
+public class ReasonDto {
+    private HttpStatus httpStatus;
+    private Integer statusCode;
+    private String message;
+}

--- a/src/main/java/com/sprarta/sproutmarket/domain/common/enums/ErrorStatus.java
+++ b/src/main/java/com/sprarta/sproutmarket/domain/common/enums/ErrorStatus.java
@@ -1,0 +1,36 @@
+package com.sprarta.sproutmarket.domain.common.enums;
+
+import com.sprarta.sproutmarket.domain.common.BaseCode;
+import com.sprarta.sproutmarket.domain.common.dto.response.ReasonDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus implements BaseCode {
+    BAD_REQUEST_EMPTY_TITLE(HttpStatus.BAD_REQUEST, 400, "제목이 비어 있습니다."),
+
+    //예외 예시
+    BAD_REQUEST_UNSUPPORTED_TOKEN(HttpStatus.BAD_REQUEST,400,"지원되지 않는 JWT 토큰입니다."),
+    BAD_REQUEST_ILLEGAL_TOKEN(HttpStatus.BAD_REQUEST,400,"잘못된 JWT 토큰입니다."),
+    UNAUTHORIZED_INVALID_TOKEN(HttpStatus.UNAUTHORIZED,401,"유효하지 않는 JWT 서명입니다."),
+    UNAUTHORIZED_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED,401,"만료된 JWT 토큰입니다."),
+    UNAUTHORIZED_TOKEN(HttpStatus.UNAUTHORIZED,401,"JWT 토큰 검증 중 오류가 발생했습니다."),
+    FORBIDDEN_TOKEN(HttpStatus.FORBIDDEN, 403, "관리자 권한이 없습니다."),
+
+    TEST_ERROR(HttpStatus.BAD_REQUEST, 400, "ApiException 예외 처리 테스트");
+
+    private final HttpStatus httpStatus;
+    private final Integer statusCode;
+    private final String message;
+
+    @Override
+    public ReasonDto getReasonHttpStatus() {
+        return ReasonDto.builder()
+                .statusCode(statusCode)
+                .httpStatus(httpStatus)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/com/sprarta/sproutmarket/domain/common/exception/ApiException.java
+++ b/src/main/java/com/sprarta/sproutmarket/domain/common/exception/ApiException.java
@@ -1,0 +1,11 @@
+package com.sprarta.sproutmarket.domain.common.exception;
+
+import com.sprarta.sproutmarket.domain.common.BaseCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ApiException extends RuntimeException {
+    private final BaseCode errorCode;
+}

--- a/src/main/java/com/sprarta/sproutmarket/domain/user/controller/UserController.java
+++ b/src/main/java/com/sprarta/sproutmarket/domain/user/controller/UserController.java
@@ -5,6 +5,7 @@ import com.sprarta.sproutmarket.domain.user.dto.request.UserDeleteRequest;
 import com.sprarta.sproutmarket.domain.user.dto.response.UserResponse;
 import com.sprarta.sproutmarket.domain.user.entity.CustomUserDetails;
 import com.sprarta.sproutmarket.domain.user.service.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;


### PR DESCRIPTION
- [x] ApiResponse에서 일관된 응답 반환 기능 구현
- [x] ErrorStatus에서 공통 예외 사항 추가 기능 구현
- [x] example도메인에 예시 코드 추가(추후 팀원 숙지시 삭제 예정)

사용법은 example의 코드처럼 ApiResponse를 한 번 더 ResponseEntity로 감싸서 넣으면 됩니다! 
그렇게 안 하고 그냥 ApiResponse만 반환하게 되면 헤더에 응답 코드가 날아가질 않아서 무조건 ResponseEntity로 한 번 더 감싸야 합니다!