### PR TITLE
Spring Rest Docs + Swagger UI 사용을 위한 의존성 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,15 @@ repositories {
     mavenCentral()
 }
 
+tasks.named('bootJar') {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+
+tasks.named('test') {
+    outputs.dir file('build/generated-snippets')  // Spring REST Docs 스니펫 저장 경로 설정
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -56,6 +65,17 @@ dependencies {
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    //API 문서 자동화 관련
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    //Spring Rest Docs 사양의 문서를 OpenAPI3 사양으로 바꿔주는 의존성
+    testImplementation 'com.epages:restdocs-api-spec-mockmvc:0.19.4'
+    //RestAssured : 통합테스트 관련 의존성
+    testImplementation 'org.springframework.restdocs:spring-restdocs-restassured'
+    // Swagger Generator (OpenAPI 스펙 기반 HTML 생성)
+    implementation 'io.swagger:swagger-generator:2.4.43'
+    // Swagger UI
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
 
 }
 

--- a/src/test/java/com/sprarta/sproutmarket/SproutMarketApplicationTests.java
+++ b/src/test/java/com/sprarta/sproutmarket/SproutMarketApplicationTests.java
@@ -5,9 +5,4 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class SproutMarketApplicationTests {
-
-    @Test
-    void contextLoads() {
-    }
-
 }


### PR DESCRIPTION
- [x] API 문서 자동화를 위한 의존성 추가

Spring Rest Docs를 위한 의존성,
레스트 독스 사양의 문서를 OpenAPI3 사양으로 바꿔주는 의존성,
통합테스트 편의 도와주는 의존성
OpenAPI3 사양의 문서를 HTML로 바꿔주는 의존성
HTML을 기반으로 Swagger UI로 바꿔주는 의존성을 추가했습니다.