### PR TITLE
주변 매물 조회 기능 추가

### DIFF
--- a/src/main/java/com/sprarta/sproutmarket/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/sprarta/sproutmarket/config/GlobalExceptionHandler.java
@@ -3,13 +3,17 @@ package com.sprarta.sproutmarket.config;
 import com.sprarta.sproutmarket.domain.common.ApiResponse;
 import com.sprarta.sproutmarket.domain.common.dto.response.ReasonDto;
 import com.sprarta.sproutmarket.domain.common.exception.ApiException;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @RestControllerAdvice
+@Order(Ordered.HIGHEST_PRECEDENCE)
 public class GlobalExceptionHandler {
 
     //공통 예외 처리
@@ -19,10 +23,16 @@ public class GlobalExceptionHandler {
         return getErrorResponse(status.getHttpStatus(), status.getMessage());
     }
 
+    //Valid 예외 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<String>> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
+        return getErrorResponse(HttpStatus.BAD_REQUEST, ex.getBindingResult().getAllErrors().get(0).getDefaultMessage());
+    }
+
     //파일 첨부 용량 초과 예외
     @ExceptionHandler(MaxUploadSizeExceededException.class)
     public ResponseEntity<ApiResponse<String>> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException ex) {
-        HttpStatus status = HttpStatus.REQUEST_ENTITY_TOO_LARGE;
+        HttpStatus status = HttpStatus.PAYLOAD_TOO_LARGE;
         return getErrorResponse(status, "파일 크기는 5MB를 초과할 수 없습니다.");
     }
 

--- a/src/main/java/com/sprarta/sproutmarket/domain/areas/controller/AdministrativeAreaController.java
+++ b/src/main/java/com/sprarta/sproutmarket/domain/areas/controller/AdministrativeAreaController.java
@@ -53,8 +53,8 @@ public class AdministrativeAreaController {
      * @return 행정동 이름 리스트 반환
      */
     @GetMapping("/test/getAreas")
-    public ResponseEntity<ApiResponse<List<AdmNameDto>>> getAreas(@RequestParam String admNm) {
-        List<AdmNameDto> areas = administrativeAreaService.findAdmNameListByAdmName(admNm);
+    public ResponseEntity<ApiResponse<List<String>>> getAreas(@RequestParam String admNm) {
+        List<String> areas = administrativeAreaService.findAdmNameListByAdmName(admNm);
         return ResponseEntity.ok(ApiResponse.onSuccess(areas));
     }
 }

--- a/src/main/java/com/sprarta/sproutmarket/domain/areas/repository/AdministrativeAreaRepository.java
+++ b/src/main/java/com/sprarta/sproutmarket/domain/areas/repository/AdministrativeAreaRepository.java
@@ -17,8 +17,8 @@ public interface AdministrativeAreaRepository extends JpaRepository<Administrati
             "WHERE ST_Contains(geometry, ST_GeomFromText(:point, 4326))", nativeQuery = true)
     Optional<String> findAdministrativeAreaByPoint(@Param("point") String point);
 
-    @Query("SELECT new com.sprarta.sproutmarket.domain.areas.dto.AdmNameDto(a.admNm) FROM AdministrativeArea a WHERE function('ST_Distance', a.admCenter, :center) <= 5000")
-    List<AdmNameDto> findAdministrativeAreasByAdmCenter(@Param("center")Point center);
+    @Query("SELECT a.admNm FROM AdministrativeArea a WHERE function('ST_Distance', a.admCenter, :center) <= 5000")
+    List<String> findAdministrativeAreasByAdmCenter(@Param("center")Point center);
 
     Optional<AdministrativeArea> findByAdmNm(String admNm);
 }

--- a/src/main/java/com/sprarta/sproutmarket/domain/areas/service/AdministrativeAreaService.java
+++ b/src/main/java/com/sprarta/sproutmarket/domain/areas/service/AdministrativeAreaService.java
@@ -145,7 +145,7 @@ public class AdministrativeAreaService {
      * @param admNm : 행정동 이름 (예시 : 부산광역시 남구 대연1동)
      * @return : 주변 5km 행정동 이름 AdmNameDto 리스트 (예시 admName : 부산광역시 남구 용당동 << 들어있는 리스트)
      */
-    public List<AdmNameDto> findAdmNameListByAdmName(String admNm) {
+    public List<String> findAdmNameListByAdmName(String admNm) {
         AdministrativeArea foundArea = administrativeAreaRepository.findByAdmNm(admNm).orElseThrow(
                 () -> new ApiException(ErrorStatus.NOT_FOUND_ADMINISTRATIVE_AREA)
         );

--- a/src/main/java/com/sprarta/sproutmarket/domain/item/controller/ItemController.java
+++ b/src/main/java/com/sprarta/sproutmarket/domain/item/controller/ItemController.java
@@ -1,12 +1,15 @@
 package com.sprarta.sproutmarket.domain.item.controller;
 
 import com.sprarta.sproutmarket.domain.common.ApiResponse;
+import com.sprarta.sproutmarket.domain.item.dto.request.FindItemsInMyAreaRequestDto;
 import com.sprarta.sproutmarket.domain.item.dto.request.ItemContentsUpdateRequest;
 import com.sprarta.sproutmarket.domain.item.dto.request.ItemCreateRequest;
 import com.sprarta.sproutmarket.domain.item.dto.response.ItemResponse;
 import com.sprarta.sproutmarket.domain.item.dto.response.ItemResponseDto;
+import com.sprarta.sproutmarket.domain.item.entity.Item;
 import com.sprarta.sproutmarket.domain.item.service.ItemService;
 import com.sprarta.sproutmarket.domain.user.entity.CustomUserDetails;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
@@ -121,6 +124,15 @@ public class ItemController {
                                                                          @PathVariable Long categoryId){
         Page<ItemResponseDto> itemResponseDto = itemService.getCategoryItems(page, size, categoryId);
         return ResponseEntity.ok(ApiResponse.onSuccess(itemResponseDto));
+    }
+
+    /**
+     * 우리 동네 매물 조회
+     */
+    @GetMapping("/myAreas")
+    public ResponseEntity<ApiResponse<Page<ItemResponseDto>>> getMyAreasItems(@RequestBody @Valid FindItemsInMyAreaRequestDto requestDto,
+                                                                   @AuthenticationPrincipal CustomUserDetails authUser) {
+        return ResponseEntity.ok(ApiResponse.onSuccess(itemService.findItemsByMyArea(authUser, requestDto)));
     }
 
 }

--- a/src/main/java/com/sprarta/sproutmarket/domain/item/dto/request/FindItemsInMyAreaRequestDto.java
+++ b/src/main/java/com/sprarta/sproutmarket/domain/item/dto/request/FindItemsInMyAreaRequestDto.java
@@ -1,0 +1,16 @@
+package com.sprarta.sproutmarket.domain.item.dto.request;
+
+import jakarta.validation.constraints.Min;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class FindItemsInMyAreaRequestDto {
+    @Min(value = 1 ,message = "페이지 번호는 최소 1입니다.")
+    private int page = 1;
+    @Min(value = 1, message = "페이지 사이즈는 최소 1입니다.")
+    private int size = 10;
+}

--- a/src/main/java/com/sprarta/sproutmarket/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/sprarta/sproutmarket/domain/item/repository/ItemRepository.java
@@ -1,6 +1,8 @@
 package com.sprarta.sproutmarket.domain.item.repository;
 
+import com.sprarta.sproutmarket.domain.areas.dto.AdmNameDto;
 import com.sprarta.sproutmarket.domain.category.entity.Category;
+import com.sprarta.sproutmarket.domain.item.dto.response.ItemResponse;
 import com.sprarta.sproutmarket.domain.item.dto.response.ItemResponseDto;
 import com.sprarta.sproutmarket.domain.item.entity.Item;
 import com.sprarta.sproutmarket.domain.user.entity.CustomUserDetails;
@@ -11,6 +13,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
@@ -29,4 +32,7 @@ public interface ItemRepository extends JpaRepository<Item, Long> {
         "JOIN FETCH i.category " +
         "WHERE i.category = :category")
     Page<Item> findByCategory(Pageable pageable, @Param("category") Category findCategory);
+
+    @Query("SELECT i FROM Item i JOIN FETCH i.seller WHERE i.seller.address IN :areaList")
+    Page<Item> findByAreaListAndUserArea(Pageable pageable, @Param("areaList") List<String> areaList);
 }

--- a/src/test/java/com/sprarta/sproutmarket/domain/areas/controller/AdministrativeAreaControllerTest.java
+++ b/src/test/java/com/sprarta/sproutmarket/domain/areas/controller/AdministrativeAreaControllerTest.java
@@ -6,7 +6,6 @@ import com.epages.restdocs.apispec.Schema;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sprarta.sproutmarket.config.JwtUtil;
 import com.sprarta.sproutmarket.config.SecurityConfig;
-import com.sprarta.sproutmarket.domain.areas.dto.AdmNameDto;
 import com.sprarta.sproutmarket.domain.areas.dto.AdministrativeAreaRequestDto;
 import com.sprarta.sproutmarket.domain.areas.service.AdministrativeAreaService;
 import com.sprarta.sproutmarket.domain.user.service.CustomUserDetailService;
@@ -143,9 +142,9 @@ class AdministrativeAreaControllerTest {
     @Test
     void 주변_행정동_조회_성공() throws Exception {
         String paramAdmNm = "경상남도 산청군 생초면";
-        List<AdmNameDto> listResult = new ArrayList<>();
-        AdmNameDto admNameDto1 = new AdmNameDto("경상남도 산청군 오부면");
-        AdmNameDto admNameDto2 = new AdmNameDto("경상남도 산청군 생초면");
+        List<String> listResult = new ArrayList<>();
+        String admNameDto1 = "경상남도 산청군 오부면";
+        String admNameDto2 = "경상남도 산청군 생초면";
         listResult.add(admNameDto1);
         listResult.add(admNameDto2);
         given(administrativeAreaService.findAdmNameListByAdmName(paramAdmNm)).willReturn(listResult);
@@ -168,7 +167,7 @@ class AdministrativeAreaControllerTest {
                                                         .description("성공 시 응답 코드 : 200"),
                                                 fieldWithPath("data")
                                                         .description("응답 본문"),
-                                                fieldWithPath("data[].admName")
+                                                fieldWithPath("data[]")
                                                         .description("행정동 이름")
                                         )
                                         .responseSchema(Schema.schema("행정동리스트-성공-응답"))
@@ -179,7 +178,7 @@ class AdministrativeAreaControllerTest {
                 );
 
         result.andExpect(status().isOk())
-                .andExpect(jsonPath("data[0].admName").value("경상남도 산청군 오부면"))
-                .andExpect(jsonPath("data[1].admName").value("경상남도 산청군 생초면"));
+                .andExpect(jsonPath("data[0]").value("경상남도 산청군 오부면"))
+                .andExpect(jsonPath("data[1]").value("경상남도 산청군 생초면"));
     }
 }

--- a/src/test/java/com/sprarta/sproutmarket/domain/areas/controller/AdministrativeAreaControllerTest.java
+++ b/src/test/java/com/sprarta/sproutmarket/domain/areas/controller/AdministrativeAreaControllerTest.java
@@ -81,7 +81,7 @@ class AdministrativeAreaControllerTest {
                                                 fieldWithPath("data").type(JsonFieldType.STRING)
                                                         .description("성공했다는 메시지")
                                         ))
-                                        .responseSchema(Schema.schema("addGeoJson-success-Response"))
+                                        .responseSchema(Schema.schema("geojson-DB-추가-성공-응답"))
                                         .build())
                         )
                 );
@@ -118,7 +118,7 @@ class AdministrativeAreaControllerTest {
                                                 fieldWithPath("latitude").type(JsonFieldType.NUMBER)
                                                         .description("경도")
                                         ))
-                                        .requestSchema(Schema.schema("get-HJD-success-Request"))
+                                        .requestSchema(Schema.schema("행정동-조회-성공-요청"))
                                         .responseFields(List.of(
                                                 fieldWithPath("message").type(JsonFieldType.STRING)
                                                         .description("Ok"),
@@ -127,7 +127,7 @@ class AdministrativeAreaControllerTest {
                                                 fieldWithPath("data").type(JsonFieldType.STRING)
                                                         .description("행정구역('시도' '시군구' '읍면동')")
                                         ))
-                                        .responseSchema(Schema.schema("get-HJD-success-response"))
+                                        .responseSchema(Schema.schema("행정동-조회-성공-응답"))
                                         .build()
                                 )
                         )
@@ -170,7 +170,7 @@ class AdministrativeAreaControllerTest {
                                                 fieldWithPath("data[]")
                                                         .description("행정동 이름")
                                         )
-                                        .responseSchema(Schema.schema("행정동리스트-성공-응답"))
+                                        .responseSchema(Schema.schema("행정동리스트-조회-성공-응답"))
                                         .build()
                                 )
 

--- a/src/test/java/com/sprarta/sproutmarket/domain/areas/controller/AdministrativeAreaControllerTest.java
+++ b/src/test/java/com/sprarta/sproutmarket/domain/areas/controller/AdministrativeAreaControllerTest.java
@@ -165,8 +165,6 @@ class AdministrativeAreaControllerTest {
                                                         .description("성공 시 응답 메시지"),
                                                 fieldWithPath("statusCode")
                                                         .description("성공 시 응답 코드 : 200"),
-                                                fieldWithPath("data")
-                                                        .description("응답 본문"),
                                                 fieldWithPath("data[]")
                                                         .description("행정동 이름")
                                         )

--- a/src/test/java/com/sprarta/sproutmarket/domain/chat/controller/ChatRoomControllerTest.java
+++ b/src/test/java/com/sprarta/sproutmarket/domain/chat/controller/ChatRoomControllerTest.java
@@ -1,95 +1,95 @@
-package com.sprarta.sproutmarket.domain.chat.controller;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sprarta.sproutmarket.domain.auth.controller.AuthController;
-import com.sprarta.sproutmarket.domain.tradeChat.controller.ChatRoomController;
-import com.sprarta.sproutmarket.domain.tradeChat.dto.ChatRoomDto;
-import com.sprarta.sproutmarket.domain.tradeChat.service.ChatRoomService;
-import com.sprarta.sproutmarket.domain.user.entity.CustomUserDetails;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.MockitoAnnotations;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
-import org.springframework.http.MediaType;
-import org.springframework.restdocs.RestDocumentationExtension;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-@WebMvcTest(ChatRoomController.class)
-@ExtendWith(RestDocumentationExtension.class)
-@MockBean(JpaMetamodelMappingContext.class)
-@AutoConfigureMockMvc(addFilters = false)
-public class ChatRoomControllerTest {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    private ObjectMapper objectMapper;
-
-    @MockBean
-    private ChatRoomService chatRoomService;
-
-    @InjectMocks
-    private ChatRoomController chatRoomController;
-
-    @BeforeEach
-    void setup() {
-        MockitoAnnotations.openMocks(this);
-        mockMvc = MockMvcBuilders
-                .standaloneSetup(chatRoomController)
-                .build();
-        objectMapper = new ObjectMapper();
-    }
-
-    @Test
-    void 채팅방_생성_성공() throws Exception {
-
-        ChatRoomDto chatRoomDto = new ChatRoomDto(
-                1L,
-                2L,
-                1L);
-
-        when(chatRoomService.createChatRoom(anyLong(), any(CustomUserDetails.class))).thenReturn(chatRoomDto);
-
-        // API 호출
-        mockMvc.perform(post("/items/{itemId}/chatrooms", 1L)
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(chatRoomDto))
-                        .principal(() -> "user")) // 인증 사용자 설정
-                .andExpect(status().isOk())
-                .andDo(print())
-                .andDo(document("create-chat-room"));
-
-    }
-
-    @Test
-    void 채팅방_조회_성공() {
-
-    }
-
-    @Test
-    void 채팅방_목록_조회_성공() {
-
-    }
-
-    @Test
-    void 채팅방_삭제_성공() {
-
-    }
-
-}
+//package com.sprarta.sproutmarket.domain.chat.controller;
+//
+//import com.fasterxml.jackson.core.JsonProcessingException;
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//import com.sprarta.sproutmarket.domain.auth.controller.AuthController;
+//import com.sprarta.sproutmarket.domain.tradeChat.controller.ChatRoomController;
+//import com.sprarta.sproutmarket.domain.tradeChat.dto.ChatRoomDto;
+//import com.sprarta.sproutmarket.domain.tradeChat.service.ChatRoomService;
+//import com.sprarta.sproutmarket.domain.user.entity.CustomUserDetails;
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.extension.ExtendWith;
+//import org.mockito.InjectMocks;
+//import org.mockito.MockitoAnnotations;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+//import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+//import org.springframework.boot.test.mock.mockito.MockBean;
+//import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+//import org.springframework.http.MediaType;
+//import org.springframework.restdocs.RestDocumentationExtension;
+//import org.springframework.test.web.servlet.MockMvc;
+//import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+//
+//import static org.mockito.ArgumentMatchers.any;
+//import static org.mockito.ArgumentMatchers.anyLong;
+//import static org.mockito.Mockito.when;
+//import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+//import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+//import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+//import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+//
+//@WebMvcTest(ChatRoomController.class)
+//@ExtendWith(RestDocumentationExtension.class)
+//@MockBean(JpaMetamodelMappingContext.class)
+//@AutoConfigureMockMvc(addFilters = false)
+//public class ChatRoomControllerTest {
+//
+//    @Autowired
+//    private MockMvc mockMvc;
+//
+//    private ObjectMapper objectMapper;
+//
+//    @MockBean
+//    private ChatRoomService chatRoomService;
+//
+//    @InjectMocks
+//    private ChatRoomController chatRoomController;
+//
+//    @BeforeEach
+//    void setup() {
+//        MockitoAnnotations.openMocks(this);
+//        mockMvc = MockMvcBuilders
+//                .standaloneSetup(chatRoomController)
+//                .build();
+//        objectMapper = new ObjectMapper();
+//    }
+//
+//    @Test
+//    void 채팅방_생성_성공() throws Exception {
+//
+//        ChatRoomDto chatRoomDto = new ChatRoomDto(
+//                1L,
+//                2L,
+//                1L);
+//
+//        when(chatRoomService.createChatRoom(anyLong(), any(CustomUserDetails.class))).thenReturn(chatRoomDto);
+//
+//        // API 호출
+//        mockMvc.perform(post("/items/{itemId}/chatrooms", 1L)
+//                        .contentType(MediaType.APPLICATION_JSON)
+//                        .content(objectMapper.writeValueAsString(chatRoomDto))
+//                        .principal(() -> "user")) // 인증 사용자 설정
+//                .andExpect(status().isOk())
+//                .andDo(print())
+//                .andDo(document("create-chat-room"));
+//
+//    }
+//
+//    @Test
+//    void 채팅방_조회_성공() {
+//
+//    }
+//
+//    @Test
+//    void 채팅방_목록_조회_성공() {
+//
+//    }
+//
+//    @Test
+//    void 채팅방_삭제_성공() {
+//
+//    }
+//
+//}

--- a/src/test/java/com/sprarta/sproutmarket/domain/item/controller/ItemControllerTest.java
+++ b/src/test/java/com/sprarta/sproutmarket/domain/item/controller/ItemControllerTest.java
@@ -6,12 +6,18 @@ import com.epages.restdocs.apispec.Schema;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sprarta.sproutmarket.config.JwtUtil;
 import com.sprarta.sproutmarket.config.SecurityConfig;
+import com.sprarta.sproutmarket.domain.common.entity.Status;
+import com.sprarta.sproutmarket.domain.item.dto.request.FindItemsInMyAreaRequestDto;
 import com.sprarta.sproutmarket.domain.item.dto.request.ItemContentsUpdateRequest;
 import com.sprarta.sproutmarket.domain.item.dto.response.ItemResponse;
+import com.sprarta.sproutmarket.domain.item.dto.response.ItemResponseDto;
+import com.sprarta.sproutmarket.domain.item.entity.ItemSaleStatus;
 import com.sprarta.sproutmarket.domain.item.service.ItemService;
 import com.sprarta.sproutmarket.domain.user.entity.CustomUserDetails;
 import com.sprarta.sproutmarket.domain.user.entity.User;
+import com.sprarta.sproutmarket.domain.user.enums.UserRole;
 import com.sprarta.sproutmarket.domain.user.service.CustomUserDetailService;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
@@ -19,25 +25,31 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.security.test.context.support.WithUserDetails;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static com.epages.restdocs.apispec.ResourceDocumentation.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ItemController.class)
@@ -63,23 +75,209 @@ class ItemControllerTest {
     @MockBean
     JpaMetamodelMappingContext jpaMappingContext;
 
-//    @Test
-//    @WithMockUser(username = "testUser", roles = {"USER"})
-//    void 매물_수정_성공() throws Exception {
-//        User user = new User();
-//        CustomUserDetails authUser = new CustomUserDetails(user);
-//        ItemResponse itemResponse = new ItemResponse("만년필","한번도안썼습니다",3000,"김커피");
-//        ItemContentsUpdateRequest requestDto = new ItemContentsUpdateRequest("만년필","한번도안썼습니다",3000,"imageUrl");
-//        Long itemId = 1L;
-//        given(itemService.updateContents(any(Long.class),any(ItemContentsUpdateRequest.class),any(CustomUserDetails.class))).willReturn(itemResponse);
-//
-//        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.post("/items/{itemId}/update/contents",itemId)
-//                .contentType(MediaType.APPLICATION_JSON)
-//                .content(objectMapper.writeValueAsString(requestDto)))
-//                .andDo(print());
-//
-//
-//        verify(itemService, times(1)).updateContents(any(Long.class),any(ItemContentsUpdateRequest.class),any(CustomUserDetails.class));
-//        result.andExpect(status().isOk());
-//    }
+    @MockBean
+    private CustomUserDetails mockAuthUser;
+
+    @BeforeEach
+    void setUp() {
+        User mockUser = new User(1L, "username", "email@example.com", "encodedOldPassword", "nickname", "010-1234-5678", "address", UserRole.USER);
+        CustomUserDetails mockAuthUser = new CustomUserDetails(mockUser);
+
+        // 인증 유저 시큐리티 컨텍스트 홀더에 저장
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(mockAuthUser, null, mockAuthUser.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @Test
+    @WithMockUser
+    void 매물_수정_성공() throws Exception {
+        ItemResponse itemResponse = new ItemResponse("만년필","한번도안썼습니다",3000,"김커피");
+        ItemContentsUpdateRequest requestDto = new ItemContentsUpdateRequest("만년필","한번도안썼습니다",3000,"imageUrl");
+        Long itemId = 1L;
+        given(itemService.updateContents(any(Long.class),any(ItemContentsUpdateRequest.class),any(CustomUserDetails.class))).willReturn(itemResponse);
+
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.post("/items/{itemId}/update/contents",itemId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto))
+                        .header("Authorization", "Bearer (JWT 토큰)"))
+                .andDo(
+                        MockMvcRestDocumentationWrapper.document(
+                                "update-Contents",
+                                resource(ResourceSnippetParameters.builder()
+                                        .description("매물의 정보를 변경합니다.")
+                                        .pathParameters(
+                                                parameterWithName("itemId").description("수정할 매물 ID")
+                                        )
+                                        .summary("매물 정보 업데이트")
+                                        .tag("Item")
+                                        .requestFields(List.of(
+                                                fieldWithPath("title").type(JsonFieldType.STRING)
+                                                        .description("수정할 제목"),
+                                                fieldWithPath("description").type(JsonFieldType.STRING)
+                                                        .description("수정할 내용"),
+                                                fieldWithPath("price").type(JsonFieldType.NUMBER)
+                                                        .description("수정할 가격"),
+                                                fieldWithPath("imageUrl").type(JsonFieldType.STRING)
+                                                        .description("변경할 이미지")
+                                        ))
+                                        .requestHeaders(
+                                                headerWithName("Authorization")
+                                                        .description("Bearer (JWT 토큰)")
+                                        )
+                                        .requestSchema(Schema.schema("매물-수정-성공-요청"))
+                                        .responseFields(
+                                                fieldWithPath("message").type(JsonFieldType.STRING)
+                                                        .description("성공 시 메시지"),
+                                                fieldWithPath("statusCode").type(JsonFieldType.NUMBER)
+                                                        .description("200 상태 코드"),
+                                                fieldWithPath("data").type(JsonFieldType.OBJECT)
+                                                        .description("반환된 정보"),
+                                                fieldWithPath("data.title").type(JsonFieldType.STRING)
+                                                        .description("수정된 제목"),
+                                                fieldWithPath("data.description").type(JsonFieldType.STRING)
+                                                        .description("수정된 내용"),
+                                                fieldWithPath("data.price").type(JsonFieldType.NUMBER)
+                                                        .description("수정된 가격"),
+                                                fieldWithPath("data.nickname").type(JsonFieldType.STRING)
+                                                        .description("수정한 유저 닉네임")
+                                        )
+                                        .responseSchema(Schema.schema("매물-수정-성공-응답"))
+                                        .build()
+                                )
+                        )
+                );
+
+        verify(itemService, times(1)).updateContents(any(Long.class),any(ItemContentsUpdateRequest.class),any(CustomUserDetails.class));
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.title").value(itemResponse.getTitle()))
+                .andExpect(jsonPath("$.data.description").value(itemResponse.getDescription()))
+                .andExpect(jsonPath("$.data.price").value(itemResponse.getPrice()));
+    }
+
+    @Test
+    @WithMockUser
+    void 내_주변_매물_조회_성공() throws Exception {
+        FindItemsInMyAreaRequestDto requestDto = new FindItemsInMyAreaRequestDto(1,10);
+        //페이지 직접 만들어주기
+        List<ItemResponseDto> dtoList = new ArrayList<>();
+        for(int i = 1; i <= 2; i++) {
+            ItemResponseDto dto = new ItemResponseDto(
+                    (long) i, //
+                    "제목" + i,
+                    "내용" + i,
+                    15000,
+                    "닉네임" + i,
+                    ItemSaleStatus.WAITING,
+                    "카테고리 이름" + i,
+                    Status.ACTIVE
+            );
+            dtoList.add(dto);
+        }
+
+        Pageable pageable = PageRequest.of(0,10);
+        Page<ItemResponseDto> pageResult = new PageImpl<>(dtoList,pageable,2);
+
+        given(itemService.findItemsByMyArea(any(CustomUserDetails.class),any(FindItemsInMyAreaRequestDto.class))).willReturn(pageResult);
+        ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/items/myAreas")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(requestDto))
+                .header("Authorization", "Bearer (JWT 토큰)"))
+                .andDo(MockMvcRestDocumentationWrapper.document(
+                        "get-items-by-my-areas",
+                        resource(ResourceSnippetParameters.builder()
+                                .description("우리 동네의 매물을 조회합니다.")
+                                .summary("동네 매물 조회")
+                                .tag("item")
+                                .requestHeaders(
+                                        headerWithName("Authorization")
+                                                .description("Bearer (JWT 토큰)")
+                                )
+                                .requestFields(
+                                        fieldWithPath("page").type(JsonFieldType.NUMBER)
+                                                .description("페이지 넘버, 기본값 1, 최소값 1"),
+                                        fieldWithPath("size").type(JsonFieldType.NUMBER)
+                                                .description("페이지 크기, 기본값 10, 최소값 1")
+                                )
+                                .responseFields(
+                                        fieldWithPath("message").type(JsonFieldType.STRING)
+                                                .description("성공 상태 메시지"),
+                                        fieldWithPath("statusCode").type(JsonFieldType.NUMBER)
+                                                .description("성공 시 응답 코드 : 200"),
+                                        fieldWithPath("data").type(JsonFieldType.OBJECT)
+                                                .description("응답 본문"),
+                                        fieldWithPath("data.content").type(JsonFieldType.ARRAY)
+                                                .description("아이템 리스트"),
+                                        fieldWithPath("data.content[].id").type(JsonFieldType.NUMBER)
+                                                .description("아이템 ID"),
+                                        fieldWithPath("data.content[].title").type(JsonFieldType.STRING)
+                                                .description("아이템 제목"),
+                                        fieldWithPath("data.content[].description").type(JsonFieldType.STRING)
+                                                .description("아이템 설명"),
+                                        fieldWithPath("data.content[].price").type(JsonFieldType.NUMBER)
+                                                .description("아이템 가격"),
+                                        fieldWithPath("data.content[].nickname").type(JsonFieldType.STRING)
+                                                .description("판매자 닉네임"),
+                                        fieldWithPath("data.content[].itemSaleStatus").type(JsonFieldType.STRING)
+                                                .description("아이템 판매 상태"),
+                                        fieldWithPath("data.content[].categoryName").type(JsonFieldType.STRING)
+                                                .description("아이템 카테고리 이름"),
+                                        fieldWithPath("data.content[].status").type(JsonFieldType.STRING)
+                                                .description("아이템 상태 (예: ACTIVE, INACTIVE)"),
+                                        fieldWithPath("data.pageable").type(JsonFieldType.OBJECT)
+                                                .description("페이지 관련 정보"),
+                                        fieldWithPath("data.pageable.pageNumber").type(JsonFieldType.NUMBER)
+                                                .description("현재 페이지 번호 (0부터 시작)"),
+                                        fieldWithPath("data.pageable.pageSize").type(JsonFieldType.NUMBER)
+                                                .description("페이지 크기"),
+                                        fieldWithPath("data.pageable.sort").type(JsonFieldType.OBJECT)
+                                                .description("정렬 정보"),
+                                        fieldWithPath("data.pageable.sort.empty").type(JsonFieldType.BOOLEAN)
+                                                .description("정렬 정보가 비어 있는지 여부"),
+                                        fieldWithPath("data.pageable.sort.sorted").type(JsonFieldType.BOOLEAN)
+                                                .description("정렬되었는지 여부"),
+                                        fieldWithPath("data.pageable.sort.unsorted").type(JsonFieldType.BOOLEAN)
+                                                .description("정렬되지 않았는지 여부"),
+                                        fieldWithPath("data.pageable.offset").type(JsonFieldType.NUMBER)
+                                                .description("현재 페이지의 시작점 오프셋"),
+                                        fieldWithPath("data.pageable.paged").type(JsonFieldType.BOOLEAN)
+                                                .description("페이징 여부"),
+                                        fieldWithPath("data.pageable.unpaged").type(JsonFieldType.BOOLEAN)
+                                                .description("페이징되지 않은 여부"),
+                                        fieldWithPath("data.last").type(JsonFieldType.BOOLEAN)
+                                                .description("마지막 페이지인지 여부"),
+                                        fieldWithPath("data.totalPages").type(JsonFieldType.NUMBER)
+                                                .description("전체 페이지 수"),
+                                        fieldWithPath("data.totalElements").type(JsonFieldType.NUMBER)
+                                                .description("전체 아이템 수"),
+                                        fieldWithPath("data.size").type(JsonFieldType.NUMBER)
+                                                .description("페이지 크기"),
+                                        fieldWithPath("data.number").type(JsonFieldType.NUMBER)
+                                                .description("현재 페이지 번호"),
+                                        fieldWithPath("data.sort").type(JsonFieldType.OBJECT)
+                                                .description("현재 페이지의 정렬 정보"),
+                                        fieldWithPath("data.sort.empty").type(JsonFieldType.BOOLEAN)
+                                                .description("현재 페이지의 정렬 정보가 비어 있는지 여부"),
+                                        fieldWithPath("data.sort.sorted").type(JsonFieldType.BOOLEAN)
+                                                .description("현재 페이지가 정렬되었는지 여부"),
+                                        fieldWithPath("data.sort.unsorted").type(JsonFieldType.BOOLEAN)
+                                                .description("현재 페이지가 정렬되지 않았는지 여부"),
+                                        fieldWithPath("data.first").type(JsonFieldType.BOOLEAN)
+                                                .description("첫 번째 페이지인지 여부"),
+                                        fieldWithPath("data.numberOfElements").type(JsonFieldType.NUMBER)
+                                                .description("현재 페이지에 있는 아이템 수"),
+                                        fieldWithPath("data.empty").type(JsonFieldType.BOOLEAN)
+                                                .description("현재 페이지가 비어 있는지 여부")
+                                )
+                                .requestSchema(Schema.schema("동네-매물-조회-성공-요청"))
+                                .responseSchema(Schema.schema("동네-매물-조회-성공-응답"))
+                                .build()
+                        )
+                ));
+
+        verify(itemService,times(1)).findItemsByMyArea(any(CustomUserDetails.class),any(FindItemsInMyAreaRequestDto.class));
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.totalElements").value(2));
+    }
+
+
 }


### PR DESCRIPTION
- [x] 회원가입 할 때 저장한 주소 기준으로 5km에 있는 매물을 조회할 수 있는 기능
- [x] 동네 매물 조회기능, 매물 수정 기능 컨트롤러 테스트 코드 작성 
- [x] @Valid 예외 ApiResponse로 반환되게 GlobalExceptionHandler에 해당 부분 추가 
- [x] static 폴더에 .gitkeep 추가해서 static 폴더 git에서 추적하게 변경 

추후 논의 후 다른 조회 기능들과 합칠 예정입니다. 