### PR TITLE
feat(notification): 거래 관련 주요 알림 (예약, 거래 완료) 구현

### DIFF
--- a/src/main/resources/templates/signin.html
+++ b/src/main/resources/templates/signin.html
@@ -168,22 +168,30 @@
 
     // WebSocket 연결 함수
     function connectWebSocket(userId) {
-        const socket = new SockJS('http://localhost:8080/ws');  // WebSocket 엔드포인트
-        const stompClient = Stomp.over(socket);
+        if (stompClient && stompClient.connected) {
+            stompClient.disconnect(() => console.log("Disconnected existing WebSocket"));
+        }
 
-        stompClient.connect({}, function (frame) {
+        const socket = new SockJS('http://localhost:8080/ws');
+        stompClient = Stomp.over(socket);
+
+        stompClient.connect({}, function(frame) {
             console.log('Connected: ' + frame);
 
-            // 해당 사용자(userId)에 대한 구독 경로
-            stompClient.subscribe('/sub/user/' + userId + '/notifications', function (message) {
-                const messageContainer = document.getElementById('messages');
-                if (messageContainer) {
-                    messageContainer.innerHTML += '<p>' + message.body + '</p>';
-                } else {
-                    console.error('Message container not found!');
-                }
+            const subscriptionPath = '/sub/user/' + userId + '/notifications';
+            stompClient.subscribe(subscriptionPath, function(message) {
+                displayMessage(message.body);
             });
         });
+    }
+
+    function displayMessage(message) {
+        const messageContainer = document.getElementById('messages');
+        if (messageContainer) {
+            messageContainer.innerHTML += '<p>' + message + '</p>';
+        } else {
+            console.error('Message container not found!');
+        }
     }
 </script>
 </body>

--- a/src/main/resources/templates/signin.html
+++ b/src/main/resources/templates/signin.html
@@ -93,6 +93,8 @@
 <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
 
 <script>
+    let stompClient = null; // 전역 변수로 설정하여 중복 연결 방지
+
     function parseJwt(token) {
         try {
             const base64Url = token.split('.')[1];


### PR DESCRIPTION
- [x] TradeService 거래 예약에서 거래가 예약되면 buyer에게 알림 보냄
- [x] TradeService 거래 완료에서 거래가 완료되면 buyer, seller에게 알림 보냄
- [x] signin.html에서 알림이 중복 발송되는 것을 방지해주는 로직 추가
- [x] signin.html에서 알림 부분의 로직을 function으로 따로 빼서 관리
 
[buyer 예약완료, 거래완료](https://github.com/user-attachments/assets/85e55442-7c07-4965-8f21-09d1ffcfea94)
[buyer 예약완료, 거래완료 개발자 화면](https://github.com/user-attachments/assets/8129b723-b49d-45d6-ac98-aaee8da6d17d)
[seller 거래완료](https://github.com/user-attachments/assets/6d885e88-0823-429b-bf09-e4098fdc2146)
[seller 거래완료 개발자 화면](https://github.com/user-attachments/assets/85b2402d-26a7-4f90-87de-041b4f8910a0)
