### PR TITLE
카테고리 관련 기능 추가, 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,6 @@ dependencies {
     implementation 'org.hibernate:hibernate-spatial:6.6.1.Final'
     implementation 'de.grundid.opendatalab:geojson-jackson:1.14'
 
-
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     //embedded-redis
@@ -128,6 +127,9 @@ dependencies {
 
     // S3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+    // 헬스체크, 캐시 확인용
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sprarta/sproutmarket/config/SecurityConfig.java
+++ b/src/main/java/com/sprarta/sproutmarket/config/SecurityConfig.java
@@ -19,7 +19,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
-@EnableMethodSecurity(prePostEnabled = true) // 최신 방식의 메서드 수준 권한 제어
+@EnableMethodSecurity // 최신 방식의 메서드 수준 권한 제어
 public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 

--- a/src/main/java/com/sprarta/sproutmarket/config/SecurityConfig.java
+++ b/src/main/java/com/sprarta/sproutmarket/config/SecurityConfig.java
@@ -50,7 +50,7 @@ public class SecurityConfig {
                         .requestMatchers("/docs/**",
                                 "/v3/api-docs/swagger-config").permitAll()
                         .requestMatchers("/admin/**",  "/test/**").hasRole("ADMIN")
-                        .requestMatchers("/","/signup", "/signin").permitAll()
+                        .requestMatchers("/signup", "/signin").permitAll()
                         .anyRequest().authenticated()
                 )
                 .build();

--- a/src/main/java/com/sprarta/sproutmarket/config/SecurityConfig.java
+++ b/src/main/java/com/sprarta/sproutmarket/config/SecurityConfig.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.apache.catalina.filters.CorsFilter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -44,14 +43,13 @@ public class SecurityConfig {
                 .logout(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/auth/**",
-                                "/test/**",
                                 "/error/**",
                                 "/notifications/**").permitAll()
                         .requestMatchers("/ws/**").permitAll() // WebSocket 접근 허용
                         //Swagger 관련 오픈
                         .requestMatchers("/docs/**",
                                 "/v3/api-docs/swagger-config").permitAll()
-                        .requestMatchers("/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/admin/**",  "/test/**").hasRole("ADMIN")
                         .requestMatchers("/","/signup", "/signin").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/com/sprarta/sproutmarket/config/SpringInMemoryCache.java
+++ b/src/main/java/com/sprarta/sproutmarket/config/SpringInMemoryCache.java
@@ -1,0 +1,9 @@
+package com.sprarta.sproutmarket.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class SpringInMemoryCache {
+}

--- a/src/main/java/com/sprarta/sproutmarket/domain/areas/service/AdministrativeAreaService.java
+++ b/src/main/java/com/sprarta/sproutmarket/domain/areas/service/AdministrativeAreaService.java
@@ -7,12 +7,11 @@ import com.sprarta.sproutmarket.domain.common.enums.ErrorStatus;
 import com.sprarta.sproutmarket.domain.common.exception.ApiException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.geojson.Feature;
 import org.geojson.FeatureCollection;
 import org.geojson.LngLatAlt;
 import org.locationtech.jts.geom.*;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.io.File;
@@ -22,7 +21,6 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
 public class AdministrativeAreaService {
     private final GeometryFactory geometryFactory = new GeometryFactory();
     private final AdministrativeAreaRepository administrativeAreaRepository;
@@ -38,7 +36,6 @@ public class AdministrativeAreaService {
     @Transactional
     public void insertGeoJsonData(String filePath) throws IOException {
         // GeoJSON 파일 읽기 및 역직렬화
-        log.info(filePath);
         File file = new File(filePath);
         FeatureCollection featureCollection = objectMapper.readValue(file, FeatureCollection.class);
 
@@ -147,6 +144,7 @@ public class AdministrativeAreaService {
      * @param admNm : 행정동 이름 (예시 : 부산광역시 남구 대연1동)
      * @return : 주변 5km 행정동 이름 AdmNameDto 리스트 (예시 admName : 부산광역시 남구 용당동 << 들어있는 리스트)
      */
+    @Cacheable(value = "admNameCache", key = "#admNm")
     public List<String> getAdmNameListByAdmName(String admNm) {
         AdministrativeArea area = administrativeAreaRepository.findByAdmNm(admNm).orElseThrow(
                 () -> new ApiException(ErrorStatus.NOT_FOUND_ADMINISTRATIVE_AREA)

--- a/src/main/java/com/sprarta/sproutmarket/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/sprarta/sproutmarket/domain/category/controller/CategoryController.java
@@ -1,5 +1,6 @@
 package com.sprarta.sproutmarket.domain.category.controller;
 
+import com.sprarta.sproutmarket.domain.category.dto.CategoryAdminResponseDto;
 import com.sprarta.sproutmarket.domain.category.dto.CategoryRequestDto;
 import com.sprarta.sproutmarket.domain.category.dto.CategoryResponseDto;
 import com.sprarta.sproutmarket.domain.category.service.CategoryService;
@@ -32,7 +33,7 @@ public class CategoryController {
     }
 
     /**
-     * 카테고리 전체 조회
+     * 활성화된 카테고리 전체 조회
      * @return CategoryResponseDto 를 담은 리스트
      */
     @GetMapping("/categories")
@@ -61,5 +62,25 @@ public class CategoryController {
     public ResponseEntity<ApiResponse<Void>> delete(@PathVariable Long categoryId) {
         categoryService.delete(categoryId);
         return ResponseEntity.ok(ApiResponse.onSuccess(null));
+    }
+
+    /**
+     * 삭제된 카테고리 복원
+     * @param categoryId 복원하고자 하는 카테고리 ID
+     * @return data: null인 응답 반환
+     */
+    @PatchMapping("/admin/categories/deleted/{categoryId}")
+    public ResponseEntity<ApiResponse<Void>> activate(@PathVariable(required = true) Long categoryId) {
+        categoryService.activate(categoryId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(null));
+    }
+
+    /**
+     * 삭제된 카테고리를 포함해서 전부 조회(어드민 전용)
+     * @return : 삭제 상태까지 포함한 응답 Dto 리스트
+     */
+    @GetMapping("/admin/categories")
+    public ResponseEntity<ApiResponse<List<CategoryAdminResponseDto>>> getCategories() {
+        return ResponseEntity.ok(ApiResponse.onSuccess(categoryService.getDeletedCategories()));
     }
 }

--- a/src/main/java/com/sprarta/sproutmarket/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/sprarta/sproutmarket/domain/category/controller/CategoryController.java
@@ -61,7 +61,8 @@ public class CategoryController {
     @DeleteMapping("/admin/categories/{categoryId}")
     public ResponseEntity<ApiResponse<Void>> delete(@PathVariable Long categoryId) {
         categoryService.delete(categoryId);
-        return ResponseEntity.ok(ApiResponse.onSuccess(null));
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
+                .body(ApiResponse.createSuccess("No Content",204,null));
     }
 
     /**
@@ -72,7 +73,8 @@ public class CategoryController {
     @PatchMapping("/admin/categories/deleted/{categoryId}")
     public ResponseEntity<ApiResponse<Void>> activate(@PathVariable(required = true) Long categoryId) {
         categoryService.activate(categoryId);
-        return ResponseEntity.ok(ApiResponse.onSuccess(null));
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
+                .body(ApiResponse.createSuccess("No Content",204,null));
     }
 
     /**

--- a/src/main/java/com/sprarta/sproutmarket/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/sprarta/sproutmarket/domain/category/controller/CategoryController.java
@@ -81,6 +81,6 @@ public class CategoryController {
      */
     @GetMapping("/admin/categories")
     public ResponseEntity<ApiResponse<List<CategoryAdminResponseDto>>> getCategories() {
-        return ResponseEntity.ok(ApiResponse.onSuccess(categoryService.getDeletedCategories()));
+        return ResponseEntity.ok(ApiResponse.onSuccess(categoryService.getAllCategories()));
     }
 }

--- a/src/main/java/com/sprarta/sproutmarket/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/sprarta/sproutmarket/domain/category/controller/CategoryController.java
@@ -71,7 +71,7 @@ public class CategoryController {
      * @return data: null인 응답 반환
      */
     @PatchMapping("/admin/categories/deleted/{categoryId}")
-    public ResponseEntity<ApiResponse<Void>> activate(@PathVariable(required = true) Long categoryId) {
+    public ResponseEntity<ApiResponse<Void>> activate(@PathVariable Long categoryId) {
         categoryService.activate(categoryId);
         return ResponseEntity.status(HttpStatus.NO_CONTENT)
                 .body(ApiResponse.createSuccess("No Content",204,null));

--- a/src/main/java/com/sprarta/sproutmarket/domain/category/dto/CategoryAdminResponseDto.java
+++ b/src/main/java/com/sprarta/sproutmarket/domain/category/dto/CategoryAdminResponseDto.java
@@ -1,0 +1,20 @@
+package com.sprarta.sproutmarket.domain.category.dto;
+
+import com.sprarta.sproutmarket.domain.category.entity.Category;
+import com.sprarta.sproutmarket.domain.common.entity.Status;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CategoryAdminResponseDto {
+    private Long categoryId;
+    private String categoryName;
+    private Status status;
+
+    public CategoryAdminResponseDto(Category category) {
+        this.categoryId = category.getId();
+        this.categoryName = category.getName();
+        this.status = category.getStatus();
+    }
+}

--- a/src/main/java/com/sprarta/sproutmarket/domain/category/entity/Category.java
+++ b/src/main/java/com/sprarta/sproutmarket/domain/category/entity/Category.java
@@ -38,6 +38,10 @@ public class Category {
         this.status = Status.DELETED;
     }
 
+    public void activate() {
+        this.status = Status.ACTIVE;
+    }
+
     public Category(String name) {
         this.name = name;
     }

--- a/src/main/java/com/sprarta/sproutmarket/domain/category/service/CategoryService.java
+++ b/src/main/java/com/sprarta/sproutmarket/domain/category/service/CategoryService.java
@@ -83,7 +83,7 @@ public class CategoryService {
 
     //삭제된 카테고리를 포함해서 조회(어드민 전용)
     @Transactional(readOnly = true)
-    public List<CategoryAdminResponseDto> getDeletedCategories() {
+    public List<CategoryAdminResponseDto> getAllCategories() {
         return categoryRepository
                 .findAll()
                 .stream().map(CategoryAdminResponseDto::new).toList();

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -31,3 +31,4 @@ spring.data.redis.host=${redis.host}
 spring.data.redis.port=${redis.port}
 
 spring.profiles.active=local
+management.endpoints.web.exposure.include=*

--- a/src/test/java/com/sprarta/sproutmarket/domain/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/sprarta/sproutmarket/domain/category/controller/CategoryControllerTest.java
@@ -216,9 +216,9 @@ class CategoryControllerTest extends CommonMockMvcControllerTestSetUp {
                 )
                 .responseFields(
                         fieldWithPath("message").type(JsonFieldType.STRING)
-                                .description("성공 시 응답 : Ok , 예외 시 예외 메시지"),
+                                .description("성공 시 응답 : No Content , 예외 시 예외 메시지"),
                         fieldWithPath("statusCode").type(JsonFieldType.NUMBER)
-                                .description("성공 상태코드 : 200"),
+                                .description("성공 상태코드 : 204"),
                         fieldWithPath("data").type(JsonFieldType.NULL)
                                 .description("성공 시 data : NULL")
                 )
@@ -234,7 +234,7 @@ class CategoryControllerTest extends CommonMockMvcControllerTestSetUp {
                 ))
                 .andDo(print());
 
-        result.andExpect(status().isOk());
+        result.andExpect(status().isNoContent());
     }
 
     @Test
@@ -256,9 +256,9 @@ class CategoryControllerTest extends CommonMockMvcControllerTestSetUp {
                 )
                 .responseFields(
                         fieldWithPath("message").type(JsonFieldType.STRING)
-                                .description("성공 시 응답 : Ok , 예외 시 예외 메시지"),
+                                .description("성공 시 응답 : No Content , 예외 시 예외 메시지"),
                         fieldWithPath("statusCode").type(JsonFieldType.NUMBER)
-                                .description("성공 상태코드 : 200"),
+                                .description("성공 상태코드 : 204"),
                         fieldWithPath("data").type(JsonFieldType.NULL)
                                 .description("성공 시 data : NULL")
                 )
@@ -274,7 +274,7 @@ class CategoryControllerTest extends CommonMockMvcControllerTestSetUp {
                 ))
                 .andDo(print());
 
-        result.andExpect(status().isOk());
+        result.andExpect(status().isNoContent());
     }
 
     @Test

--- a/src/test/java/com/sprarta/sproutmarket/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/sprarta/sproutmarket/domain/category/service/CategoryServiceTest.java
@@ -62,16 +62,6 @@ class CategoryServiceTest {
     }
 
     @Test
-    void 카테고리_수정_실패__수정할_이름과_현재_이름이_같음() {
-        CategoryRequestDto requestDto = new CategoryRequestDto("디지털");
-
-        given(categoryRepository.findByIdAndStatusIsActive(1L)).willReturn(Optional.of(category));
-
-        assertThrows(ApiException.class, () -> categoryService.update(1L,requestDto));
-        verify(categoryRepository,times(1)).findByIdAndStatusIsActive(1L);
-    }
-
-    @Test
     void 카테고리_삭제_성공() {
         given(categoryRepository.findByIdAndStatusIsActive(1L)).willReturn(Optional.of(category));
 


### PR DESCRIPTION
- [x] 삭제된 카테고리를 포함해서 전체 조회할 수 있는 어드민 전용 기능
- [x] 삭제된 카테고리를 복원할 수 있는 어드민 전용 기능 
- [x] 주변 행정동 리스트 조회 스프링 인메모리 캐싱 처리
- [x] 헬스체크, 캐싱 내역 확인, 추후 로깅을 위한 actuator 의존성 추가

그 외 리팩토링 내역

 수정/삭제를 할 때 마지막에 categoryrepository.save()를 하는데, findById 같은 걸로 조회할 때 영속화된 엔티티가 변경이 일어날 때 Hibernate의 Dirty Check가 작동을 하므로 해당 메서드 사용 지웠습니다. 

test로 시작하는 URL 어드민 권한을 가진 유저만 접근할 수 있도록 변경했습니다.

수정/삭제 할 때 지금 void로 응답을 주는데도 200 응답 코드를 주던 것을 204로 수정했습니다.



