### PR TITLE
응답시 data null이면 필드 반환 안 하게 수정, 테스트코드 수정, 오타 수정

### DIFF
--- a/src/main/java/com/sprarta/sproutmarket/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/sprarta/sproutmarket/domain/category/controller/CategoryController.java
@@ -28,8 +28,8 @@ public class CategoryController {
      */
     @PostMapping("/admin/categories")
     public ResponseEntity<ApiResponse<CategoryResponseDto>> create(@RequestBody @Valid CategoryRequestDto requestDto) {
-        CategoryResponseDto responseDto = categoryService.create(requestDto);
-        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.createSuccess("Created",201,responseDto));
+        return ResponseEntity.status(HttpStatus.CREATED).body(
+                ApiResponse.createSuccess("Created",201,categoryService.create(requestDto)));
     }
 
     /**
@@ -38,7 +38,8 @@ public class CategoryController {
      */
     @GetMapping("/categories")
     public ResponseEntity<ApiResponse<List<CategoryResponseDto>>> getAll() {
-        return ResponseEntity.ok(ApiResponse.onSuccess(categoryService.getActiveCategories()));
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(categoryService.getActiveCategories()));
     }
 
     /**
@@ -50,7 +51,8 @@ public class CategoryController {
     @PatchMapping("/admin/categories/{categoryId}")
     public ResponseEntity<ApiResponse<CategoryResponseDto>> update(@RequestBody @Valid CategoryRequestDto requestDto,
                                                                    @PathVariable Long categoryId) {
-        return ResponseEntity.ok(ApiResponse.onSuccess(categoryService.update(categoryId, requestDto)));
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(categoryService.update(categoryId, requestDto)));
     }
 
     /**
@@ -61,8 +63,8 @@ public class CategoryController {
     @DeleteMapping("/admin/categories/{categoryId}")
     public ResponseEntity<ApiResponse<Void>> delete(@PathVariable Long categoryId) {
         categoryService.delete(categoryId);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT)
-                .body(ApiResponse.createSuccess("No Content",204,null));
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(null));
     }
 
     /**
@@ -73,8 +75,8 @@ public class CategoryController {
     @PatchMapping("/admin/categories/deleted/{categoryId}")
     public ResponseEntity<ApiResponse<Void>> activate(@PathVariable Long categoryId) {
         categoryService.activate(categoryId);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT)
-                .body(ApiResponse.createSuccess("No Content",204,null));
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(null));
     }
 
     /**
@@ -83,6 +85,7 @@ public class CategoryController {
      */
     @GetMapping("/admin/categories")
     public ResponseEntity<ApiResponse<List<CategoryAdminResponseDto>>> getCategories() {
-        return ResponseEntity.ok(ApiResponse.onSuccess(categoryService.getAllCategories()));
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(categoryService.getAllCategories()));
     }
 }

--- a/src/main/java/com/sprarta/sproutmarket/domain/common/ApiResponse.java
+++ b/src/main/java/com/sprarta/sproutmarket/domain/common/ApiResponse.java
@@ -1,5 +1,6 @@
 package com.sprarta.sproutmarket.domain.common;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sprarta.sproutmarket.domain.common.enums.ErrorStatus;
 import lombok.Getter;
 
@@ -8,6 +9,7 @@ public class ApiResponse<T> {
 
     private final String message;
     private final Integer statusCode;
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private final T data;
 
     private ApiResponse(String message, Integer statusCode, T data) {
@@ -26,9 +28,5 @@ public class ApiResponse<T> {
 
     public static <T> ApiResponse<T> onSuccess(T result) {
         return new ApiResponse<>("Ok", 200, result);
-    }
-
-    public static ApiResponse<String> onFailure(ErrorStatus errorStatus) {
-        return new ApiResponse<>(errorStatus.getMessage(), errorStatus.getStatusCode(), null);
     }
 }

--- a/src/main/java/com/sprarta/sproutmarket/domain/item/service/ItemService.java
+++ b/src/main/java/com/sprarta/sproutmarket/domain/item/service/ItemService.java
@@ -419,7 +419,7 @@ public class ItemService {
                 })
                 .sorted(Comparator.comparingLong(ItemWithViewCount::getViewCount).reversed()) // 조회수 내림차순 정렬
                 .limit(5) // 상위 3개 선택
-                .collect(Collectors.toList());
+                .toList();
 
         // ItemWithViewCount를 ItemResponseDto로 변환하여 반환
         return itemWithViewCounts.stream()

--- a/src/main/java/com/sprarta/sproutmarket/domain/review/enums/ReviewRating.java
+++ b/src/main/java/com/sprarta/sproutmarket/domain/review/enums/ReviewRating.java
@@ -2,6 +2,6 @@ package com.sprarta.sproutmarket.domain.review.enums;
 
 public enum ReviewRating {
 
-    GOOD, AVERAGE, BAD;
+    GOOD, AVERAGE, BAD
 
 }

--- a/src/main/java/com/sprarta/sproutmarket/domain/trade/service/TradeService.java
+++ b/src/main/java/com/sprarta/sproutmarket/domain/trade/service/TradeService.java
@@ -28,7 +28,7 @@ public class TradeService {
     private final TradeRepository tradeRepository;
     private final ItemRepository itemRepository;
     private final UserRepository userRepository;
-    private final SimpMessagingTemplate simpMessagingTemplate;;
+    private final SimpMessagingTemplate simpMessagingTemplate;
 
     // 예약
     @Transactional

--- a/src/main/java/com/sprarta/sproutmarket/domain/tradeChat/controller/ChatRoomController.java
+++ b/src/main/java/com/sprarta/sproutmarket/domain/tradeChat/controller/ChatRoomController.java
@@ -30,7 +30,7 @@ public class ChatRoomController {
     }
 
     // 채팅방 조회
-    @GetMapping("/chatrooms/{chatroomId}")
+    @GetMapping("/chatrooms/{chatRoomId}")
     public ResponseEntity<ApiResponse<ChatRoomDto>> getChatRoom(
             @PathVariable Long chatRoomId, @AuthenticationPrincipal CustomUserDetails authUser) {
         ChatRoomDto chatRoomDto = chatRoomService.getChatRoom(

--- a/src/test/java/com/sprarta/sproutmarket/domain/areas/controller/AdministrativeAreaControllerTest.java
+++ b/src/test/java/com/sprarta/sproutmarket/domain/areas/controller/AdministrativeAreaControllerTest.java
@@ -13,15 +13,12 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.ResultActions;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName;
-import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
-import static org.mockito.ArgumentMatchers.anyString;
+import static com.epages.restdocs.apispec.ResourceDocumentation.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -44,6 +41,7 @@ class AdministrativeAreaControllerTest extends CommonMockMvcControllerTestSetUp 
                 .thenReturn(returnString);
 
         ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.post("/test/getHJD")
+                        .header("Authorization", "Bearer (JWT 토큰)")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(requestDto)))
                 .andDo(
@@ -53,6 +51,10 @@ class AdministrativeAreaControllerTest extends CommonMockMvcControllerTestSetUp 
                                         .description("double 타입의 위도, 경도를 받아서 특정 행정구역을 리턴합니다.")
                                         .summary("행정구역 반환 API")
                                         .tag("AdministrativeArea")
+                                        .requestHeaders(
+                                                headerWithName("Authorization")
+                                                        .description("Bearer (JWT 토큰)")
+                                        )
                                         .requestFields(List.of(
                                                 fieldWithPath("longitude").type(JsonFieldType.NUMBER)
                                                         .description("위도"),
@@ -90,6 +92,7 @@ class AdministrativeAreaControllerTest extends CommonMockMvcControllerTestSetUp 
         listResult.add(admNameDto2);
         given(administrativeAreaService.getAdmNameListByAdmName(paramAdmNm)).willReturn(listResult);
         ResultActions result = mockMvc.perform(RestDocumentationRequestBuilders.get("/test/getAreas")
+                        .header("Authorization", "Bearer (JWT 토큰)")
                         .queryParam("admNm", paramAdmNm))
                 .andDo(MockMvcRestDocumentationWrapper.document(
                                 "get-admNm-List",
@@ -97,6 +100,10 @@ class AdministrativeAreaControllerTest extends CommonMockMvcControllerTestSetUp 
                                         .description("특정 행정동을 받아서 주변 5km의 행정동 이름을 담은 리스트를 반환")
                                         .summary("주변 행정동 리스트 반환")
                                         .tag("AdministrativeArea")
+                                        .requestHeaders(
+                                                headerWithName("Authorization")
+                                                        .description("Bearer (JWT 토큰)")
+                                        )
                                         .queryParameters(
                                                 parameterWithName("admNm")
                                                         .description("행정동 이름")

--- a/src/test/java/com/sprarta/sproutmarket/domain/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/sprarta/sproutmarket/domain/category/controller/CategoryControllerTest.java
@@ -189,8 +189,7 @@ class CategoryControllerTest extends CommonMockMvcControllerTestSetUp {
                 .andDo(MockMvcRestDocumentationWrapper.document(
                         "update-category",
                         resource(params)
-                ))
-                .andDo(print());
+                ));
 
         result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.data.categoryId").value(1L))
@@ -216,11 +215,9 @@ class CategoryControllerTest extends CommonMockMvcControllerTestSetUp {
                 )
                 .responseFields(
                         fieldWithPath("message").type(JsonFieldType.STRING)
-                                .description("성공 시 응답 : No Content , 예외 시 예외 메시지"),
+                                .description("성공 시 응답 : OK , 예외 시 예외 메시지"),
                         fieldWithPath("statusCode").type(JsonFieldType.NUMBER)
-                                .description("성공 상태코드 : 204"),
-                        fieldWithPath("data").type(JsonFieldType.NULL)
-                                .description("성공 시 data : NULL")
+                                .description("성공 상태코드 : 200")
                 )
                 .requestSchema(Schema.schema("카테고리-삭제-성공-요청"))
                 .responseSchema(Schema.schema("카테고리-삭제-성공-응답"))
@@ -231,8 +228,7 @@ class CategoryControllerTest extends CommonMockMvcControllerTestSetUp {
                 .andDo(MockMvcRestDocumentationWrapper.document(
                         "delete-category",
                         resource(params)
-                ))
-                .andDo(print());
+                ));
 
         result.andExpect(status().isNoContent());
     }
@@ -256,11 +252,9 @@ class CategoryControllerTest extends CommonMockMvcControllerTestSetUp {
                 )
                 .responseFields(
                         fieldWithPath("message").type(JsonFieldType.STRING)
-                                .description("성공 시 응답 : No Content , 예외 시 예외 메시지"),
+                                .description("성공 시 응답 : Ok , 예외 시 예외 메시지"),
                         fieldWithPath("statusCode").type(JsonFieldType.NUMBER)
-                                .description("성공 상태코드 : 204"),
-                        fieldWithPath("data").type(JsonFieldType.NULL)
-                                .description("성공 시 data : NULL")
+                                .description("성공 상태코드 : 200")
                 )
                 .requestSchema(Schema.schema("카테고리-복원-성공-요청"))
                 .responseSchema(Schema.schema("카테고리-복원-성공-응답"))
@@ -271,8 +265,7 @@ class CategoryControllerTest extends CommonMockMvcControllerTestSetUp {
                 .andDo(MockMvcRestDocumentationWrapper.document(
                         "recover-category",
                         resource(params)
-                ))
-                .andDo(print());
+                ));
 
         result.andExpect(status().isNoContent());
     }
@@ -316,8 +309,7 @@ class CategoryControllerTest extends CommonMockMvcControllerTestSetUp {
                 .andDo(MockMvcRestDocumentationWrapper.document(
                         "category-get-all",
                         resource(params)
-                ))
-                .andDo(print());
+                ));
 
         result.andExpect(status().isOk());
     }

--- a/src/test/java/com/sprarta/sproutmarket/domain/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/sprarta/sproutmarket/domain/category/controller/CategoryControllerTest.java
@@ -230,7 +230,7 @@ class CategoryControllerTest extends CommonMockMvcControllerTestSetUp {
                         resource(params)
                 ));
 
-        result.andExpect(status().isNoContent());
+        result.andExpect(status().isOk());
     }
 
     @Test
@@ -267,7 +267,7 @@ class CategoryControllerTest extends CommonMockMvcControllerTestSetUp {
                         resource(params)
                 ));
 
-        result.andExpect(status().isNoContent());
+        result.andExpect(status().isOk());
     }
 
     @Test

--- a/src/test/java/com/sprarta/sproutmarket/domain/report/controller/ReportControllerTest.java
+++ b/src/test/java/com/sprarta/sproutmarket/domain/report/controller/ReportControllerTest.java
@@ -298,9 +298,7 @@ class ReportControllerTest extends CommonMockMvcControllerTestSetUp {
                                         fieldWithPath("message")
                                                 .description("성공 메시지 : Ok"),
                                         fieldWithPath("statusCode")
-                                                .description("성공 상태 코드 : 200"),
-                                        fieldWithPath("data")
-                                                .description("따로 반환하는 본문 없습니다. : null")
+                                                .description("성공 상태 코드 : 200")
                                 )
                                 .responseSchema(Schema.schema("신고-삭제-성공-응답"))
                                 .build()

--- a/src/test/java/com/sprarta/sproutmarket/domain/review/controller/ReviewControllerTest.java
+++ b/src/test/java/com/sprarta/sproutmarket/domain/review/controller/ReviewControllerTest.java
@@ -306,8 +306,7 @@ class ReviewControllerTest {
                                 .tag("Review")
                                 .responseFields(List.of(
                                         fieldWithPath("message").description("응답 메시지"),
-                                        fieldWithPath("statusCode").description("HTTP 상태 코드"),
-                                        fieldWithPath("data").description("리뷰 삭제에 대한 데이터 (null)")
+                                        fieldWithPath("statusCode").description("HTTP 상태 코드")
                                 ))
                                 .responseHeaders(
                                         headerWithName("Content-Type").description("응답의 Content-Type")

--- a/src/test/java/com/sprarta/sproutmarket/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/sprarta/sproutmarket/domain/user/controller/UserControllerTest.java
@@ -135,8 +135,7 @@ public class UserControllerTest {
                                 .tag("User")
                                 .responseFields(List.of(
                                         fieldWithPath("message").description("에러 메시지"),
-                                        fieldWithPath("statusCode").description("응답 상태 코드"),
-                                        fieldWithPath("data").description("응답 데이터, 실패 시 null 반환").optional()
+                                        fieldWithPath("statusCode").description("응답 상태 코드")
                                 ))
                                 .responseSchema(Schema.schema("유저-조회-실패-응답"))
                                 .build())
@@ -180,7 +179,6 @@ public class UserControllerTest {
     @WithMockUser
     void changePasswordFail_IncorrectOldPassword() throws Exception {
         // given
-        UserChangePasswordRequest passwordRequest = new UserChangePasswordRequest("wrongOldPassword", "NewPass1!");
         doThrow(new ApiException(ErrorStatus.BAD_REQUEST_PASSWORD))
                 .when(userService).changePassword(any(CustomUserDetails.class), any(UserChangePasswordRequest.class));
 
@@ -196,8 +194,7 @@ public class UserControllerTest {
                                 .tag("User")
                                 .responseFields(List.of(
                                         fieldWithPath("message").description("에러 메시지"),
-                                        fieldWithPath("statusCode").description("응답 상태 코드"),
-                                        fieldWithPath("data").description("응답 데이터, 실패 시 null 반환").optional()
+                                        fieldWithPath("statusCode").description("응답 상태 코드")
                                 ))
                                 .responseSchema(Schema.schema("비밀번호-변경-실패-응답"))
                                 .build())
@@ -208,7 +205,6 @@ public class UserControllerTest {
     @WithMockUser
     void deleteUserSuccess() throws Exception {
         // given
-        UserDeleteRequest deleteRequest = new UserDeleteRequest("password");
 
         // when, then
         mockMvc.perform(delete("/users")
@@ -254,8 +250,7 @@ public class UserControllerTest {
                                 .tag("User")
                                 .responseFields(List.of(
                                         fieldWithPath("message").description("에러 메시지"),
-                                        fieldWithPath("statusCode").description("응답 상태 코드"),
-                                        fieldWithPath("data").description("응답 데이터, 실패 시 null 반환").optional()
+                                        fieldWithPath("statusCode").description("응답 상태 코드")
                                 ))
                                 .responseSchema(Schema.schema("유저-삭제-실패-응답"))
                                 .build())


### PR DESCRIPTION
수정/삭제시 Data를 Null로 반환하고, ApiResponse에서 null인 필드를 반환하지 않게 변경했습니다. 

저렇게 변경하고 컨트롤러 테스트 코드의 문서화 코드에서 data 필드가 없다고 실패하는 오류를 수정했습니다. 

PathVariable에서 주소는 chatroomId로, 변수는 chatRoomId로 오타가 있어서 수정했습니다. 