### PR TITLE
feat(notification): Redis를 사용한 알림 캐싱 및 조회 기능 추가

### DIFF
--- a/src/main/java/com/sprarta/sproutmarket/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/sprarta/sproutmarket/domain/notification/controller/NotificationController.java
@@ -1,0 +1,29 @@
+package com.sprarta.sproutmarket.domain.notification.controller;
+
+import com.sprarta.sproutmarket.domain.notification.service.NotificationCacheService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/notifications")
+public class NotificationController {
+    private final NotificationCacheService notificationCacheService;
+
+    // 안읽은 알림 조회
+    @GetMapping("/{userId}/unread")
+    public ResponseEntity<List<Object>> getUnreadNotifications(@PathVariable Long userId) {
+        List<Object> unreadNotifications = notificationCacheService.getUnreadNotifications(userId);
+        return ResponseEntity.ok(unreadNotifications);
+    }
+
+    // 알림 읽음 처리
+    @PostMapping("/{userId}/mark-as-read")
+    public ResponseEntity<Void> markNotificationsAsRead(@PathVariable Long userId) {
+        notificationCacheService.markNotificationsAsRead(userId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/sprarta/sproutmarket/domain/notification/service/NotificationCacheService.java
+++ b/src/main/java/com/sprarta/sproutmarket/domain/notification/service/NotificationCacheService.java
@@ -1,0 +1,33 @@
+package com.sprarta.sproutmarket.domain.notification.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationCacheService {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    private static final String NOTIFICATION_KEY_PREFIX = "user:%d:notifications";
+
+    public void saveNotification(Long userId, String message) {
+        String key = String.format(NOTIFICATION_KEY_PREFIX, userId);
+        redisTemplate.opsForList().rightPush(key, message);
+        // 알림의 TTL 설정, 3일 후 삭제
+        redisTemplate.expire(key, Duration.ofDays(3));
+    }
+
+    public List<Object> getUnreadNotifications(Long userId) {
+        String key = String.format(NOTIFICATION_KEY_PREFIX, userId);
+        return redisTemplate.opsForList().range(key, 0, -1); // 모든 읽지 않은 알림 반환
+    }
+
+    public void markNotificationsAsRead(Long userId) {
+        String key = String.format(NOTIFICATION_KEY_PREFIX, userId);
+        redisTemplate.delete(key); // 읽음 처리 시 알림 삭제
+    }
+}


### PR DESCRIPTION
- [x] Redis를 활용한 알림 캐싱 기능 구현: 사용자별 알림을 Redis에 저장하고 TTL 설정으로 3일 후 자동 삭제되도록 처리
- [x] 알림 조회 및 읽음 처리 API 추가: 읽지 않은 알림을 조회하고, 읽음 처리 시 Redis 데이터를 삭제하는 API를 구현
- [x] WebSocket과 Redis 연동: 실시간 알림 전송과 캐싱을 병행하여 효율적인 알림 관리 구조로 구현